### PR TITLE
Enable setting  button type inside the Tooltip component

### DIFF
--- a/src/lib/components/Tooltip/Tooltip.js
+++ b/src/lib/components/Tooltip/Tooltip.js
@@ -29,6 +29,7 @@ import positionTooltip from "../../helpers/positionTooltip.js";
     onClick [Function] - A function to run when the button is clicked.
     position [String] - The tooltip position. One of "bottom", "left", "right", or "top".
     url [String] - A url to link to. Will take precedence over onClick.
+    buttonType [String] - A valid html button type that will render if the Tooltip is showing a <button>
 */
 
 const Tooltip = (props) => {
@@ -41,6 +42,7 @@ const Tooltip = (props) => {
     text,
     tooltipBody,
     url,
+    buttonType
   } = props;
 
   const tooltipElementId = `${id}-desc`;
@@ -82,6 +84,7 @@ const Tooltip = (props) => {
         className={triggerClass}
         onClick={onClick}
         onMouseEnter={handleMouseEnter}
+        type={buttonType}
       >
         {text}
       </button>
@@ -118,6 +121,7 @@ const Tooltip = (props) => {
 
 Tooltip.defaultProps = {
   position: "top",
+  buttonType: "button"
 };
 
 Tooltip.propTypes = {
@@ -129,6 +133,7 @@ Tooltip.propTypes = {
   position: PropTypes.oneOf(["bottom", "left", "right", "top"]),
   text: PropTypes.string.isRequired,
   url: PropTypes.string,
+  buttonType: PropTypes.oneOf(["button", "submit", "reset"]),
 };
 
 export default Tooltip;

--- a/src/pages/TooltipPage.js
+++ b/src/pages/TooltipPage.js
@@ -43,6 +43,14 @@ const TooltipPage = () => {
               text="abstract"
             />
           </li>
+          <li>
+            <Tooltip
+              tooltipBody="This is a tooltip with type reset."
+              id="reset-tooltip"
+              text="reset"
+              buttonType="reset"
+            />
+          </li>
         </ol>
       </div>
     </div>


### PR DESCRIPTION
This is helpful when embedded inside Formik or other libs that hook into button types to actions.

* Update Tooltip.js to have default buttonType prop
* Update TooltipPage to test for type reset.